### PR TITLE
Resolve TMPBASE deletion failure due to duplicate cleanup

### DIFF
--- a/install-perfsonar
+++ b/install-perfsonar
@@ -141,6 +141,20 @@ TMPBASE=$(mktemp -d)
 
 cleanup()
 {
+    case "$?" in
+	0)
+	    printf "\n\nInstallation completed successfully.\n\n" | tee -a "${LOG}"
+	    ;;
+	*)
+	    printf "\n\nINSTALLATION FAILED\n\n" | tee -a "${LOG}"
+	    ;;
+    esac
+
+    if [ -f "${LOG}" ]
+    then
+	echo "Output logged to ${LOG}"
+    fi
+
     rm -rf "${TMPBASE}"
 }
 trap cleanup EXIT
@@ -265,26 +279,6 @@ esac
 
 
 [ $(id -u) -eq 0 ] || die "This program must be run as root."
-
-
-cleanup()
-{
-    case "$?" in
-	0)
-	    printf "\n\nInstallation completed successfully.\n\n" | tee -a "${LOG}"
-	    ;;
-	*)
-	    printf "\n\nINSTALLATION FAILED\n\n" | tee -a "${LOG}"
-	    ;;
-    esac
-
-    if [ -f "${LOG}" ]
-    then
-	echo "Output logged to ${LOG}"
-    fi
-
-}
-trap cleanup EXIT
 
 
 install_redhat()


### PR DESCRIPTION
The TMPBASE directory was not being deleted because the `cleanup` function was declared twice. This commit merges the duplicate declarations into a single function, ensuring that the directory is properly removed after use.